### PR TITLE
Add -s flag to curl to avoid leaking webhook URL

### DIFF
--- a/out
+++ b/out
@@ -16,7 +16,7 @@ webhook_url=$(jq -r '.source.url' < $payload)
 
 body=$(jq -c '{"text":(.params.text // ""), "username": (.params.username // null), "icon_url": (.params.icon_url // null), "icon_emoji": (.params.icon_emoji // null), "channel": (.params.channel // null)}' < $payload)
 
-curl -X POST --data-urlencode "payload=$body" $webhook_url
+curl -s -X POST --data-urlencode "payload=$body" $webhook_url
 
 jq -n '{version:{ref:0}}' >&3
 


### PR DESCRIPTION
Currently the webhook URL is visible which is a potential DoS vector. Therefore this output cannot be used in publically-visible jobs.

This PR sets curl to silent, such that the output is not visible.
